### PR TITLE
Refactored node_apo and node_peri to use node_alt

### DIFF
--- a/node_alt.ks
+++ b/node_alt.ks
@@ -6,23 +6,23 @@
 /////////////////////////////////////////////////////////////////////////////
 
 parameter alt.
+parameter nodetime is time:seconds + 120.
 
-local mu is constant():G * ship:obt:body:mass.
-local rb is ship:obt:body:radius.
-local burnTime is time:seconds + 120.
+local mu is body:mu.
+local br is body:radius.
 
 // present orbit properties
-local vom is VELOCITYAT(ship,burnTime):orbit:mag.  // actual velocity
-local r is rb + altitude.
-local va is sqrt( vom^2 ). // velocity in periapsis
-local a is (periapsis + 2*rb + apoapsis)/2. // semi major axis present orbit
+local vom is ship:velocity:orbit:mag.  // current velocity
+local r is br + altitude.  // current radius
+local v1 is velocityat(ship, nodetime):orbit:mag. // velocity at burn time
+local sma1 is orbit:semimajoraxis.
 
 // future orbit properties
-local r2 is rb + altitude.
-local a2 is (alt + 2*rb + periapsis)/2. // semi major axis target orbit
-local v2 is sqrt( vom^2 + (mu * (2/r2 - 2/r + 1/a - 1/a2 ) ) ).
+local r2 is br + ship:body:altitudeof(positionat(ship, nodetime)).
+local sma2 is (alt + br + r2)/2.
+local v2 is sqrt( vom^2 + (mu * (2/r2 - 2/r + 1/sma1 - 1/sma2 ) ) ).
 
 // create node
-local deltav is v2 - va.
-local nd is node(burnTime, 0, 0, deltav).
+local deltav is v2 - v1.
+local nd is node(nodetime, 0, 0, deltav).
 add nd.

--- a/node_apo.ks
+++ b/node_apo.ks
@@ -2,28 +2,10 @@
 // Change apoapsis.
 /////////////////////////////////////////////////////////////////////////////
 // Establish new apoapsis by performing a burn at periapsis.
+// An optional argument allows for scheduling the burn at another time.
 /////////////////////////////////////////////////////////////////////////////
 
 parameter alt.
+parameter nodetime is time:seconds + eta:periapsis.
 
-local mu is body:mu.
-local br is body:radius.
-
-// present orbit properties
-local vom is ship:obt:velocity:orbit:mag.      // actual velocity
-local r is br + altitude.                      // actual distance to body
-local ra is br + periapsis.                    // radius at burn apsis
-local v1 is sqrt( vom^2 + 2*mu*(1/ra - 1/r) ). // velocity at burn apsis
-
-// true story: if you name this "a" and call it from circ_alt, its value is 100,000 less than it should be!
-local sma1 is obt:semimajoraxis.
-
-// future orbit properties
-local r2 is br + periapsis.                    // distance after burn at periapsis
-local sma2 is (alt + 2*br + periapsis)/2. // semi major axis target orbit
-local v2 is sqrt( vom^2 + (mu * (2/r2 - 2/r + 1/sma1 - 1/sma2 ) ) ).
-
-// create node
-local deltav is v2 - v1.
-local nd is node(time:seconds + eta:periapsis, 0, 0, deltav).
-add nd.
+run node_alt(alt, nodetime).

--- a/node_peri.ks
+++ b/node_peri.ks
@@ -2,27 +2,10 @@
 // Change periapsis.
 /////////////////////////////////////////////////////////////////////////////
 // Establish new periapsis by performing a burn at apoapsis.
+// An optional argument allows for scheduling the burn at another time.
 /////////////////////////////////////////////////////////////////////////////
 
 parameter alt.
+parameter nodetime is time:seconds + eta:apoapsis.
 
-local mu is body:mu.
-local br is body:radius.
-
-// present orbit properties
-local vom is ship:velocity:orbit:mag.               // actual velocity
-local r is br + altitude.                      // actual distance to body
-local ra is br + apoapsis.                     // radius at burn apsis
-local v1 is sqrt( vom^2 + 2*mu*(1/ra - 1/r) ). // velocity at burn apsis
-// true story: if you name this "a" and call it from circ_alt, its value is 100,000 less than it should be!
-local sma1 is (periapsis + 2*br + apoapsis)/2. // semi major axis present orbit
-
-// future orbit properties
-local r2 is br + apoapsis.               // distance after burn at apoapsis
-local sma2 is (alt + 2*br + apoapsis)/2. // semi major axis target orbit
-local v2 is sqrt( vom^2 + (mu * (2/r2 - 2/r + 1/sma1 - 1/sma2 ) ) ).
-
-// create node
-local deltav is v2 - v1.
-local nd is node(time:seconds + eta:apoapsis, 0, 0, deltav).
-add nd.
+run node_alt(alt, nodetime).


### PR DESCRIPTION
The node_alt script has the same logic as the node_apo and node_peri scripts.
To conserve diskspace on the units, I have replaced the duplicate logic with
calls to the node_alt script, reducing the code size by over forty percent.